### PR TITLE
Event implements Render interface

### DIFF
--- a/sse-encoder.go
+++ b/sse-encoder.go
@@ -90,6 +90,11 @@ func (r Event) Render(w http.ResponseWriter) error {
 	return Encode(w, r)
 }
 
+func (r Event) Write(w http.ResponseWriter) error {
+
+	return Encode(w, r)
+}
+
 func kindOfData(data interface{}) reflect.Kind {
 	value := reflect.ValueOf(data)
 	valueType := value.Kind()


### PR DESCRIPTION
we use gin as our webserver,but It build failed. As this,"cannot use sse.Event literal (type sse.Event) as type render.Render", so push this.
